### PR TITLE
Do not require ssh credentials to clone repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ajt_common"]
 	path = card_management/ajt_common
-	url = git@github.com:Ajatt-Tools/ajt_common.git
+	url = https://github.com/Ajatt-Tools/ajt_common.git


### PR DESCRIPTION
Otherwise you cannot clone the repo with the submodules if you are on eg a CI system.