### PR TITLE
Shuffle cards before putting them in learning queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ meta.json
 *.ankiaddon
 .mypy_cache
 *TODO*
+__about__.py

--- a/card_management/config.py
+++ b/card_management/config.py
@@ -10,5 +10,9 @@ class LearnNowConfig(AddonConfigManager):
     def randomize_card_due(self) -> bool:
         return bool(self["randomize_card_due"])
 
+    @property
+    def learn_shortcut(self) -> str:
+        return self["learn_shortcut"]
+
 
 config = LearnNowConfig()

--- a/card_management/learn_now.py
+++ b/card_management/learn_now.py
@@ -86,17 +86,15 @@ def reps_to_graduate(col: Collection, card: Card) -> int:
     return reps_left * 1000 + reps_left
 
 
-def get_due_offset() -> int:
+def get_due_offset(randomize: bool) -> int:
     """
     By default, the add-on adds some randomness to due dates
     to make sure that the order of cards doesn't affect retention.
     """
-    from .config import config
-
-    return random.randint(0, 100) if config.randomize_card_due else 0
+    return random.randint(0, 100) if randomize else 0
 
 
-def put_in_learning(col: Collection, card: Card) -> None:
+def put_in_learning(col: Collection, card: Card, randomize: bool) -> None:
     # https://github.com/ankidroid/Anki-Android/wiki/Database-Structure
 
     # learn card
@@ -108,7 +106,7 @@ def put_in_learning(col: Collection, card: Card) -> None:
     card.original_position = card.odue if card.odid else card.due
 
     # due date, like this: 1608939774
-    card.due = int(time.time() - get_due_offset())
+    card.due = int(time.time() - get_due_offset(randomize))
 
     # number of reps left till graduation
     card.left = reps_to_graduate(col, card)
@@ -123,8 +121,12 @@ def put_in_learning(col: Collection, card: Card) -> None:
 
 @with_undo_entry(undo_msg="Put cards in learning")
 def put_cards_in_learning(col: Collection, cards: Sequence[Card]) -> OpChanges:
+    from .config import config
+    randomize = config.randomize_card_due
+    if randomize:
+        random.shuffle(cards)
     for card in cards:
-        put_in_learning(col, card)
+        put_in_learning(col, card, randomize)
 
     # save the cards and add an undo entry.
     return col.update_cards(cards)

--- a/card_management/learn_now.py
+++ b/card_management/learn_now.py
@@ -5,21 +5,20 @@
 import functools
 import random
 import time
-from collections.abc import Sequence, Iterator
-from collections.abc import Sized
+from collections.abc import Iterator, MutableSequence, Sized
 from gettext import ngettext
-from typing import Callable
-from typing import Optional
+from typing import Callable, Optional
 
 from anki.cards import Card
 from anki.collection import Collection, OpChanges
 from anki.decks import DeckConfigDict
 from aqt import qconnect
 from aqt.browser import Browser
-from aqt.operations import CollectionOp
-from aqt.operations import ResultWithChanges
+from aqt.operations import CollectionOp, ResultWithChanges
 from aqt.qt import QKeySequence
 from aqt.utils import tooltip
+
+from .config import config
 
 
 def notify_user(msg: str) -> None:
@@ -86,27 +85,29 @@ def reps_to_graduate(col: Collection, card: Card) -> int:
     return reps_left * 1000 + reps_left
 
 
-def get_due_offset(randomize: bool) -> int:
+def get_due_offset() -> int:
     """
     By default, the add-on adds some randomness to due dates
     to make sure that the order of cards doesn't affect retention.
     """
-    return random.randint(0, 100) if randomize else 0
+    if config.randomize_card_due:
+        return random.randint(0, 1000)
+    return 0
 
 
-def put_in_learning(col: Collection, card: Card, randomize: bool) -> None:
+def put_in_learning(col: Collection, card: Card) -> None:
     # https://github.com/ankidroid/Anki-Android/wiki/Database-Structure
 
     # learn card
-    card.type = 1
-    card.queue = 1
+    card.type = 1  # type: ignore
+    card.queue = 1  # type: ignore
     card.ivl = 0
 
     # save card's original position
     card.original_position = card.odue if card.odid else card.due
 
     # due date, like this: 1608939774
-    card.due = int(time.time() - get_due_offset(randomize))
+    card.due = int(time.time() - get_due_offset())
 
     # number of reps left till graduation
     card.left = reps_to_graduate(col, card)
@@ -120,13 +121,11 @@ def put_in_learning(col: Collection, card: Card, randomize: bool) -> None:
 
 
 @with_undo_entry(undo_msg="Put cards in learning")
-def put_cards_in_learning(col: Collection, cards: Sequence[Card]) -> OpChanges:
-    from .config import config
-    randomize = config.randomize_card_due
-    if randomize:
+def put_cards_in_learning(col: Collection, cards: MutableSequence[Card]) -> OpChanges:
+    if config.randomize_card_due:
         random.shuffle(cards)
     for card in cards:
-        put_in_learning(col, card, randomize)
+        put_in_learning(col, card)
 
     # save the cards and add an undo entry.
     return col.update_cards(cards)


### PR DESCRIPTION
Currently, when using the learn now button, the order of the cards is not randomized enough. I still see the cards in almost the same order as they appear in the selection.

After this change, they are shuffled better.